### PR TITLE
Update checksums

### DIFF
--- a/zip.py
+++ b/zip.py
@@ -70,11 +70,12 @@ class Zippy():
         md5 = hashlib.md5()
         md5.update(data)
         valid_md5s = [
-            "116381392460d655b6a76c24d4afd694",
-            "ab83621ad43d493504359e69c3911b6c",
-            "3dbd7af96d90aaab326765ea367e586a",
+            "116381392460d655b6a76c24d4afd694", # mi3/DRV016
+            "ab83621ad43d493504359e69c3911b6c", # lite/DRV242
+            "0e6268dfcb539b6c7319da3a7bc5bbe3", # lite/DRV245
+            "3dbd7af96d90aaab326765ea367e586a", # pro2/DRV247
             "39d256fd99a7670d57b957b007cca42c",
-            "aa70bd3bcd329eb00953afa1e0cc1888",
+            "aa70bd3bcd329eb00953afa1e0cc1888", # 1s/DRV319
             "26d8eb9abc836ee709cf9abdb2cd463a"
         ]
         return md5.hexdigest() in valid_md5s


### PR DESCRIPTION
I have added a checksum for the DRV245, I have nowhere to get the rest from. I have also added comments, which will make it easier to keep an eye on which version of the frmware is missing. Without adding checksums on a regular basis, the option to package NGFW in a zip does not work afterwards with newer firmwares. 