### PR TITLE
Fix exception output when uploading invalid file for model lock

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -115,7 +115,7 @@ class FirmwarePatcher():
         pre = self.data[ofs:ofs+2]
         post = pre.copy()
         if pre[-1] != 0xd0:
-            raise Exception(f"invalid firmware file: {hex(pre)}")
+            raise Exception(f"invalid firmware file: {pre.hex()}")
         post[-1] = 0xe0
         self.data[ofs:ofs+2] = post
         return [("no_modellock", hex(ofs), pre.hex(), post.hex())]


### PR DESCRIPTION
Fixes the following exception:

    Traceback (most recent call last):
      File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1499, in full_dispatch_request
        rv = self.dispatch_request()
      File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1485, in dispatch_request
        return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
      File "/home/nextgenfw/app/__init__.py", line 260, in patch_firmware
        res, data_patched = patch(data)
      File "/home/nextgenfw/app/__init__.py", line 225, in patch
        res.append(("Remove Model Lock", patcher.remove_modellock()))
      File "/home/nextgenfw/./patcher.py", line 118, in remove_modellock
        raise Exception(f"invalid firmware file: {hex(pre)}")
    TypeError: 'bytearray' object cannot be interpreted as an integer

This can be reproduced by uploading the `FIRM.bin` from `DRV016-COMPAT.zip`, as reported by someone in the ScooterHacking telegram group:

[Link removed by dnandha]

Speculative fix, but I'm rather certain it'll work - not sure what the underlying issue is exactly, but that should at least show a better message.