### PR TITLE
More universal signatures for skip_key_check

### DIFF
--- a/nb_patcher.py
+++ b/nb_patcher.py
@@ -43,13 +43,11 @@ class NbPatcher(BasePatcher):
         OP: WallyCZ
         Description: Skips key check
         '''
-        sig = self.asm('ldrb.w r12,[r12,#0x5]')
-        ofs = FindPattern(self.data, sig)
-        sig = self.asm('cmp r0, #0x10')
-        ofs = FindPattern(self.data, sig, start=ofs) + 4
+        sig = [0x40, 0x1c, 0x10, 0x28, None, 0xdb, 0x00, 0x20, None, 0x4b]
+        ofs = FindPattern(self.data, sig) + 6
 
-        sig = self.asm('strb.w r11,[r6,#0x5]')
-        ofs_dst = FindPattern(self.data, sig, start=ofs) - 2
+        sig = [0xf2, 0xdb, 0x0c, 0xb9, 0x86, 0xf8, 0x05]
+        ofs_dst = FindPattern(self.data, sig, start=ofs) + 2
 
         pre = self.data[ofs:ofs+2]
         post = self.asm(f'b #{ofs_dst-ofs}')


### PR DESCRIPTION
This way, the patch also works for other models such as the old F-series or G30.